### PR TITLE
Update README to match dst-guides standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,34 @@
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's Gemfile
 
 ```ruby
 gem 'ea-validation'
 ```
 
-And then execute:
+And then execute
 
     $ bundle
 
-Or install it yourself as:
+Or install it yourself as
 
     $ gem install ea-validation
 
 ## Usage
 
-With this gem installed, a number of active model based validators become
-available:
+With this gem installed, a number of active model based validators become available.
 
 ### Companies House Name
 
-There are a number of restrictions as to what comprises a company name valid
-for Companies House registration. This validator checks that the name complies
-to these restrictions.
+There are a number of restrictions as to what comprises a company name valid for Companies House registration. This validator checks that the name complies to these restrictions.
 
 ```ruby
 validates :company_name, "ea/validation/companies_house_name" => true
 ```
 ### Companies House number
 
-As with company names, there are also restrictions to the form of a company
-registration number. This validator checks that the company registration
-number complies to these restrictions.
+As with company names, there are also restrictions to the form of a company registration number. This validator checks that the company registration number complies to these restrictions.
 
 ```ruby
 validates :number, "ea/validation/companies_house_number" => true
@@ -42,8 +37,7 @@ validates :number, "ea/validation/companies_house_number" => true
 
 ### Grid Reference
 
-A grid reference should be of the form AA 12345 67890 (spaces optional).
-The validator checks the format, and the the grid reference is valid.
+A grid reference should be of the form AA 12345 67890 (spaces optional). The validator checks the format, and the the grid reference is valid.
 
 ```ruby
 validates :grid_reference, "ea/validation/grid_reference" => true
@@ -51,8 +45,7 @@ validates :grid_reference, "ea/validation/grid_reference" => true
 
 ## Modifications
 
-Options can be passed into validation by replacing `true` with an options
-hash. For example:
+Options can be passed into validation by replacing `true` with an options hash. For example
 
 ```ruby
 validates(
@@ -63,3 +56,25 @@ validates(
   }
 )
 ```
+
+## Contributing to this project
+
+If you have an idea you'd like to contribute please log an issue.
+
+All contributions should be submitted via a pull request.
+
+## License
+
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
+
+http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+> Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.


### PR DESCRIPTION
[DST Guides](https://github.com/EnvironmentAgency/dst-guides) contains details for the style rules we apply to markdown files, and what a README should contain.

This change updates the README to match the standard set in DST Guides.
