### PR TITLE
Remove before_commit and rspec dev dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,6 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "before_commit"
-spec = Gem::Specification.find_by_name "before_commit"
-load "#{spec.gem_dir}/lib/tasks/before_commit.rake"
-
 task test: :spec
 
-task :rubocop do
-  sh 'rubocop -D'
-end
-
-task default: [:rubocop, :test]
+task default: :test

--- a/ea-validation.gemspec
+++ b/ea-validation.gemspec
@@ -6,12 +6,12 @@ require "ea/validation/version"
 Gem::Specification.new do |spec|
   spec.name          = "ea-validation"
   spec.version       = Ea::Validation::VERSION
-  spec.authors       = ["Rob Nichols"]
-  spec.email         = ["git@nicholshayes.co.uk"]
+  spec.authors       = ["Rob Nichols, Alan Cruikshanks"]
+  spec.email         = ["alan.cruikshanks@environment-agency.gov.uk"]
   spec.license       = "LICENSE"
   spec.summary       = "Package of validations commonly used in EA projects"
   spec.description   = "Package containing validations: ."
-  spec.homepage      = "https://github.com/reggieb/ea-validation"
+  spec.homepage      = "https://github.com/EnvironmentAgency/ea-validation"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "before_commit"
   spec.add_development_dependency "virtus"
-  spec.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
Previously we had a model of using a gem we created called [Before_commit](https://github.com/EnvironmentAgency/before_commit) in our projects. It would run a series of checks at each commit to ensure the code being commited met various standards and agreed styles.

However we are moving to a model of instead having a central repo of linters and rule files, which would be used as part of the CI build for a project but locally it will be left to the developer to choose how they wish to check their submissions.

This commits includes the following changes
- Removes the **Before_commit** and **Rubocop** gems from the gemspec
- Corrects some of the gemspec info now that the project falls under the EA organisation
