### PR TITLE
Add support for integrating codeclimate with repo

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,21 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: false
+  rubymotion:
+    enabled: false
+ratings:
+  paths:
+  - "**.module"
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-
-# Overcommit configuration files
-.overcommit*
-.git-hooks/
-rubocop/
-.rubocop.yml
-.htmlhintrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,109 @@
+AllCops:
+  TargetRubyVersion: 2.3
+  # Cop names are not displayed in offense messages by default. We find it useful to include this information so we can
+  # use it to investigate what the fix may be.
+  DisplayCopNames: true
+  # Style guide URLs are not displayed in offense messages by default. Again we find it useful to go straight to the
+  # documentation for a rule when investigating what the fix may be.
+  DisplayStyleGuide: true
+  Include:
+    - "**/*.gemspec"
+    - "**/*.rake"
+    - "**/*.rb"
+    - "**/Gemfile"
+    - "**/Rakefile"
+    - "**/bin/*"
+    - "**/config.ru"
+  Exclude:
+    - "config/**/*"
+    - "script/**/*"
+    - !ruby/regexp /old_and_unused\.rb$/
+    # Rubocop is accidentally linting HTML ERB files in Atom Editor https://github.com/AtomLinter/linter-rubocop/issues/48
+    - "**/*.html.erb"
+    # Bin contains standard files created when Rails is initialised and therefore they should be left as is
+    - "bin/**/*"
+    # Rakefile is generated when Rails is initialised and therefore should be left as is
+    - "Rakefile"
+    # spec_helper is generated when rspec is initialised and therefore should be left as is
+    - "spec/spec_helper.rb"
+    - "**/db/schema.rb"
+    - "**/db/migrate/*"
+    - .git-hooks/**/*
+
+# When using Ruby >= 2.3, Rubocop wants to add a comment to the top of *.rb
+# to aid migration to frozen literals in Ruby 3.0. We are not interested in
+# modifying every file at this point, so this cop is disabled for now.
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# TODO: Understand what the issue is and whether this needs to be more formally disabled (i.e. the dev team agree)
+# We don't understand this for now - seems to prevent perfectly reasonable meta-programming
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+# We felt as a team that the default size of 15 was too low, and blocked what to us are sound methods which would not
+# add any value if broken up, for exampler composer type methods. Therefore we agreed to up the score to 20 to allow
+# for these types of methods
+Metrics/AbcSize:
+  Max: 20
+
+# We believe the default of 10 lines for a method length is too restrictive and often quickly hit just because we need
+# to specify the namesspace, class and method before then doing something with it.
+Metrics/MethodLength:
+  Max: 15
+
+# Specs can get large and with good reason, no benefit splitting them up
+Metrics/ModuleLength:
+  Max: 200
+  Exclude:
+    - spec/**/*_spec.rb
+
+# We believe the default 80 characters is too restrictive and that lines can still be readable and maintainable
+# when no more than 120 characters. This also allows us to maximise our scree space.
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - spec/factories/*.rb
+    - spec/features/*_spec.rb
+    - spec/routing/*_spec.rb
+
+# Turn these off as can totally mess with the expect{...}.to syntax
+# Also reports on model validations using Proc.new { style blocks but trying to use do .. end raises invalid syntax
+Style/BlockDelimiters:
+  Exclude:
+    - spec/**/*_spec.rb
+
+# Rubymine disagrees and not sure how to fix Rubymine indentation right now
+Style/CaseIndentation:
+  Enabled: false
+
+# As a web app, as long as the team commit to using well named classes for
+# controllers, models etc it should not be necessary to add top-level class
+# documentation.
+Style/Documentation:
+  Enabled: false
+
+# Looks cluttered/ugly having your first method directly after the module/class declaration
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+
+# We've found the sprintf style for formatting strings can be useful when storing a formatted string as a template,
+# and passing in strings that can vary with context. Therefore we chose to disable this rule.
+Style/FormatString:
+  Enabled: false
+
+Style/MethodCalledOnDoEndBlock:
+  Exclude:
+    - spec/**/*_spec.rb
+
+# There are no relative performance improvements using '' over "", therefore we believe there is more
+# value in using "" for all strings irrespective of whether string interpolation is used
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# Rubocop 0.42 introduced this cop - disabling for now until we have time to resolve
+# the issues it raises.
+Style/MethodMissing:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: ruby
-rvm:
-  - 2.2.4
+cache: bundler
+rvm: 2.2.4
 before_install: gem install bundler -v 1.11.2
+
+# This section was added as per https://docs.travis-ci.com/user/code-climate/
+# To protect our codeclimate stats rather than adding the Codeclimate API key for ea-area_lookup
+# in the open we used this guide https://docs.travis-ci.com/user/encryption-keys/ to encryt the
+# value. Essentially install travis gem, then run `travis encrypt <my_code_climate_api_key>`
+addons:
+  code_climate:
+    repo_token:
+      secure: "Z/CQJouf45LH6D34mYc0a0mwTk2iHkMRnqMcPWO4Qm5Ov7KQ4e/Echi4lNHSYwODLsnxfTz0ZEhFKXHhPTSWffQ2y4UxE8wko9EeWaTQ/4G+IwRiphfuLZcqwG2Gz/X0PBEBMperVHewrL5lXkd966+wR7Ej/+q95VikM6ePQiKchVt722rxPmdRyEWzRNZaJGIN2RHY/8m9/TPURovUjERMF57LsuaeGBY/9wBBQgWftd6C8iO0QSU7sN+geq67PXQQmVA2Sv/WoQLJ7ZyRDCUTntFv8prKWlDx8s7JAJgkN7/zuCzeI+lbdidEzaQZAyNjPBaIMZSf9q3wefhS0ctlXyIR69JULOJqc/UVWg57cuP3gXXhBiWETTGBKjMyIh8zvqLDApEe6yqtRaq+Vg3Pv5N041e+pyDiNuDnOWUMHb8ObD8HUXqwR9XsXQNGb7c8ut/Ml6+ZwDVLOhR6fGY6ykUD7gFCwOCKw156Ko6XBefDhoWv0oCQ16o4LU/yHXFiPY2mXIvHw1HPzG8cLNvc5jGzJoFDZ7xr4Ck3YUIOwwx2RsgFEUPeSoEbvJuhTn90oa77dQ2CAEe/XF1JNVjW706PHjdvIGy54+htP483ECKw/TnXds6JIK3nUPXM/zLGn5uzHAx1wXAS7RX75ICH9mJjt+kDK3cnwSIodZQ="

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ea-validation.gemspec
 gemspec
+
+# Required to enable codeclimate's test coverage functionality
+gem "codeclimate-test-reporter", group: :test, require: nil

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ea::Validation
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/ea-validation.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/ea-validation)
+[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/ea-validation/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-validation)
+[![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/ea-validation/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-validation/coverage)
 [![security](https://hakiri.io/github/EnvironmentAgency/ea-validation/master.svg)](https://hakiri.io/github/EnvironmentAgency/ea-validation/master)
 [![Dependency Status](https://dependencyci.com/github/EnvironmentAgency/ea-validation/badge)](https://dependencyci.com/github/EnvironmentAgency/ea-validation)
 

--- a/ea-validation.gemspec
+++ b/ea-validation.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 0.42"
   spec.add_development_dependency "virtus"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ea/validation'


### PR DESCRIPTION
We use codeclimate to monitor the quality of our code and the coverage of our testing. This commit covers the changes required to enable these things to happen. It covers
- Adding `.codeclimate.yml` config file
- Adding `codeclimate-test-reporter` gem to support code coverage, plus reference to it in `spec/spec_helper`
- Adding `.rubocop.yml` and dev dependency for **Rubocop** so CodeClimate uses our rules not just the standard
- Updating `.travis.yml` so after build on master code coverage stats can be sent to CodeClimate
- Adding badges to the README
- Removing `.rubocop.yml` from `.gitignore` (along with some old references to overcommit and before_commit stuff)
